### PR TITLE
create new event for trigger as current one is marked with stopPropagati...

### DIFF
--- a/src/SlmQueue/Strategy/AttachQueueListenersStrategy.php
+++ b/src/SlmQueue/Strategy/AttachQueueListenersStrategy.php
@@ -93,6 +93,10 @@ class AttachQueueListenersStrategy extends AbstractStrategy
         }
 
         $e->stopPropagation();
-        $eventManager->trigger(WorkerEvent::EVENT_BOOTSTRAP, $e);
+
+        $workerEvent  = new WorkerEvent($e->getTarget(), $e->getQueue());
+        $workerEvent->setOptions($e->getOptions());
+
+        $eventManager->trigger(WorkerEvent::EVENT_BOOTSTRAP, $workerEvent);
     }
 }

--- a/src/SlmQueue/Strategy/AttachQueueListenersStrategy.php
+++ b/src/SlmQueue/Strategy/AttachQueueListenersStrategy.php
@@ -92,11 +92,6 @@ class AttachQueueListenersStrategy extends AbstractStrategy
             ));
         }
 
-        $e->stopPropagation();
-
-        $workerEvent  = new WorkerEvent($e->getTarget(), $e->getQueue());
-        $workerEvent->setOptions($e->getOptions());
-
-        $eventManager->trigger(WorkerEvent::EVENT_BOOTSTRAP, $workerEvent);
+        $eventManager->trigger(WorkerEvent::EVENT_BOOTSTRAP, $e);
     }
 }

--- a/tests/SlmQueueTest/Strategy/AttachQueueListenersStrategyTest.php
+++ b/tests/SlmQueueTest/Strategy/AttachQueueListenersStrategyTest.php
@@ -138,4 +138,27 @@ class AttachQueueListenersStrategyTest extends PHPUnit_Framework_TestCase
         $this->setExpectedException('SlmQueue\Exception\RunTimeException');
         $this->listener->attachQueueListeners($this->event);
     }
+
+    public function testAttachQueueListenersRetriggersBoostrapEvent()
+    {
+        $workerMock       = $this->event->getTarget();
+        $eventManagerMock = $workerMock->getEventManager();
+
+        $eventManagerMock->expects($this->once())->method('getEvents')->will($this->returnValue(array(WorkerEvent::EVENT_PROCESS_QUEUE)));
+        $eventManagerMock->expects($this->once())->method('trigger')->with(WorkerEvent::EVENT_BOOTSTRAP, $this->event);
+
+        $this->listener->attachQueueListeners($this->event);
+    }
+
+    public function testAttachQueueListenersDoesNotStopEventPropagation()
+    {
+        $workerMock       = $this->event->getTarget();
+        $eventManagerMock = $workerMock->getEventManager();
+
+        $eventManagerMock->expects($this->once())->method('getEvents')->will($this->returnValue(array(WorkerEvent::EVENT_PROCESS_QUEUE)));
+
+        $this->listener->attachQueueListeners($this->event);
+
+        $this->assertFalse($this->event->propagationIsStopped());
+    }
 }


### PR DESCRIPTION
...on`WorkerEvent::EVENT_BOOTSTRAP` is trigger but since $e->stopPropagation is called the event never reaches any listeners. Create a new event with same payload events now go to listeners.