### PR TITLE
create max polling strategy

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -25,6 +25,7 @@ return array(
                 'SlmQueue\Strategy\MaxRunsStrategy' => array('max_runs' => 100000),
                 'SlmQueue\Strategy\MaxMemoryStrategy' => array('max_memory' => 100 * 1024 * 1024),
                 'SlmQueue\Strategy\InterruptStrategy',
+                'SlmQueue\Strategy\MaxPollingFrequencyStrategy' => array('max_frequency' => 0)
             ),
             'queues' => array( // per queue
                 'default' => array(
@@ -58,6 +59,7 @@ return array(
                 'SlmQueue\Strategy\MaxRunsStrategy'         => 'SlmQueue\Strategy\MaxRunsStrategy',
                 'SlmQueue\Strategy\MaxMemoryStrategy'       => 'SlmQueue\Strategy\MaxMemoryStrategy',
                 'SlmQueue\Strategy\FileWatchStrategy'       => 'SlmQueue\Strategy\FileWatchStrategy',
+                'SlmQueue\Strategy\MaxPollingFrequencyStrategy' => 'SlmQueue\Strategy\MaxPollingFrequencyStrategy',
             ),
             'factories' => array(
                 'SlmQueue\Strategy\AttachQueueListenersStrategy' => 'SlmQueue\Strategy\Factory\AttachQueueListenersStrategyFactory',

--- a/src/SlmQueue/Strategy/MaxPollingFrequencyStrategy.php
+++ b/src/SlmQueue/Strategy/MaxPollingFrequencyStrategy.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace SlmQueue\Strategy;
+
+use SlmQueue\Worker\WorkerEvent;
+use Zend\EventManager\EventManagerInterface;
+use SlmQueue\Strategy\AbstractStrategy;
+
+class MaxPollingFrequencyStrategy extends AbstractStrategy
+{
+    protected $maxFrequency = 0;
+
+    protected $lastTime = 0;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function attach(EventManagerInterface $events, $priority = 1)
+    {
+        $this->listeners[] = $events->attach(
+            WorkerEvent::EVENT_PROCESS_QUEUE,
+            array($this, 'onQueueProcessFinish'),
+            1000
+        );
+    }
+
+    public function onQueueProcessFinish(WorkerEvent $event)
+    {
+        if($this->maxFrequency == 0) {
+            return;
+        }
+
+        $startTime = microtime(true);
+        $time = ($startTime - $this->lastTime);
+
+        $minTime = 1 / $this->maxFrequency;
+
+        if($time < $minTime) {
+            $waitTime = $minTime - $time;
+            usleep($waitTime * 1000000);
+        }
+
+        $this->lastTime = microtime(true);
+    }
+
+    /**
+     * @param mixed $maxFrequency
+     */
+    public function setMaxFrequency($maxFrequency)
+    {
+        $this->maxFrequency = $maxFrequency;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getMaxFrequency()
+    {
+        return $this->maxFrequency;
+    }
+}

--- a/tests/SlmQueueTest/Strategy/MaxPollingFrequencyStrategyTest.php
+++ b/tests/SlmQueueTest/Strategy/MaxPollingFrequencyStrategyTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace SlmQueueTest\Strategy;
+
+use PHPUnit_Framework_TestCase;
+use SlmQueue\Strategy\MaxPollingFrequencyStrategy;
+use SlmQueue\Worker\WorkerEvent;
+use SlmQueueTest\Asset\SimpleJob;
+
+class MaxPollingFrequencyStrategyTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * @var MaxPollingFrequencyStrategy
+     */
+    protected $listener;
+
+    /**
+     * @var WorkerEvent
+     */
+    protected $event;
+
+    public function setUp()
+    {
+        $queue = $this->getMockBuilder('SlmQueue\Queue\AbstractQueue')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $worker = $this->getMock('SlmQueue\Worker\WorkerInterface');
+
+        $ev    = new WorkerEvent($worker, $queue);
+        $job   = new SimpleJob();
+
+        $ev->setJob($job);
+
+        $this->listener = new MaxPollingFrequencyStrategy();
+        $this->event    = $ev;
+    }
+
+    public function testListenerInstanceOfAbstractStrategy()
+    {
+        $this->assertInstanceOf('SlmQueue\Strategy\AbstractStrategy', $this->listener);
+    }
+
+    public function testMaxPollingFrequencyDefault()
+    {
+        $this->assertTrue($this->listener->getMaxFrequency() == 0);
+    }
+
+    public function testMaxPollingFrequencySetter()
+    {
+        $this->listener->setMaxFrequency(100);
+
+        $this->assertTrue($this->listener->getMaxFrequency() == 100);
+    }
+
+    public function testListensToCorrectEvents()
+    {
+        $evm = $this->getMock('Zend\EventManager\EventManagerInterface');
+
+        $evm->expects($this->at(0))->method('attach')
+            ->with(WorkerEvent::EVENT_PROCESS_QUEUE, array($this->listener, 'onQueueProcessFinish'));
+
+        $this->listener->attach($evm);
+    }
+
+    public function testNoDelayWhenFrequencyIsZero()
+    {
+        $this->listener->setMaxFrequency(0);
+
+        $startTime = microtime(true);
+        $this->listener->onQueueProcessFinish($this->event);
+        $this->listener->onQueueProcessFinish($this->event);
+        $endTime = microtime(true);
+        $delay = $endTime - $startTime;
+
+        $this->assertLessThan(10, $delay); // 10 ms
+    }
+
+    public function testDelayWhenFrequencyIsSet()
+    {
+        $this->listener->setMaxFrequency(1);
+
+        $startTime = microtime(true);
+        $this->listener->onQueueProcessFinish($this->event);
+        $this->listener->onQueueProcessFinish($this->event);
+        $endTime = microtime(true);
+        $delay = round($endTime - $startTime);
+
+        $this->assertEquals(1, $delay);
+    }
+}


### PR DESCRIPTION
Hey,

I'm using this module with the extension SlmQueue SQS. 
In 5 days, this module did 5 millions requests. Far too much compare to my needs and also its includes a cost.

So I created a strategy to limit the max polling frequency. 

When frequency is set to 0, it means that the strategy dont operate.
When frequency is at 0.1, this process the queue every 10 seconds.
