### PR TITLE
Update docs to make Supervisord keep running

### DIFF
--- a/docs/7.WorkerManagement.md
+++ b/docs/7.WorkerManagement.md
@@ -37,8 +37,9 @@ name.
 
 ```ini
 [program:my-app]
-command = php /var/www/mysite/public/index.php queue beanstalkd default
-user    = www-data
+command     = php /var/www/mysite/public/index.php queue beanstalkd default
+user        = www-data
+autorestart = true
 ```
 
 For every program, at least the `command` line must be set, as supervisord must know which process it should manage.
@@ -66,6 +67,7 @@ user         = www-data
 command      = php /var/www/mysite/public/index.php queue beanstalkd
 numprocs     = 3
 process_name = my-app-worker-%(process_num)
+autorestart  = true
 ```
 
 Navigation


### PR DESCRIPTION
By default supervisord is configured to only restart jobs that terminate unexpected. SlmQueue _does_ terminate correctly if one of its stopping criteria is met. However this does not mean that supervisord should not restart them. In fact: it should!