### PR TITLE
Fix/clear previous jobs from reused event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.4.2
+
+- Jobs (and execution result) weren't removed from the (reused) WorkerEvent until a new job was processed. These
+ 'lingering' jobs are now cleared whenever 'pop' is called on the queue by the ProcessQueueStrategy. 
+
 # 0.4.1
 
 - Add a new `MaxPollingFrequencyStrategy` that allows you to limit the rate at which messages are polled.

--- a/src/SlmQueue/Queue/QueueInterface.php
+++ b/src/SlmQueue/Queue/QueueInterface.php
@@ -36,7 +36,7 @@ interface QueueInterface
      * Pop a job from the queue
      *
      * @param  array $options
-     * @return JobInterface
+     * @return JobInterface|null
      */
     public function pop(array $options = array());
 

--- a/src/SlmQueue/Strategy/ProcessQueueStrategy.php
+++ b/src/SlmQueue/Strategy/ProcessQueueStrategy.php
@@ -40,6 +40,8 @@ class ProcessQueueStrategy extends AbstractStrategy
         $worker       = $e->getTarget();
         $eventManager = $worker->getEventManager();
 
+        $e->setJob($job);
+
         // The queue may return null, for instance if a timeout was set
         if (!$job instanceof JobInterface) {
             $eventManager->trigger(WorkerEvent::EVENT_PROCESS_IDLE, $e);
@@ -49,8 +51,6 @@ class ProcessQueueStrategy extends AbstractStrategy
 
             return;
         }
-
-        $e->setJob($job);
 
         $eventManager->trigger(WorkerEvent::EVENT_PROCESS_JOB, $e);
     }

--- a/src/SlmQueue/Worker/WorkerEvent.php
+++ b/src/SlmQueue/Worker/WorkerEvent.php
@@ -81,10 +81,10 @@ class WorkerEvent extends Event
     }
 
     /**
-     * @param  JobInterface $job
+     * @param  JobInterface|null $job
      * @return void
      */
-    public function setJob(JobInterface $job)
+    public function setJob(JobInterface $job = null)
     {
         $this->job = $job;
         $this->setResult(self::JOB_STATUS_UNKNOWN);

--- a/tests/SlmQueueTest/Strategy/ProcessQueueStrategyTest.php
+++ b/tests/SlmQueueTest/Strategy/ProcessQueueStrategyTest.php
@@ -105,6 +105,8 @@ class ProcessQueueStrategyTest extends PHPUnit_Framework_TestCase
         $this->listener->onJobPop($this->event);
 
         $this->assertTrue($called);
+        $this->assertNull($this->event->getJob());
+        $this->assertEquals(WorkerEvent::JOB_STATUS_UNKNOWN, $this->event->getResult());
         $this->assertTrue($this->event->propagationIsStopped());
     }
 

--- a/tests/SlmQueueTest/Worker/WorkerEventTest.php
+++ b/tests/SlmQueueTest/Worker/WorkerEventTest.php
@@ -40,4 +40,33 @@ class WorkerEventTest extends TestCase
 
         $this->assertEquals($job, $event->getJob());
     }
+
+    /**
+     * Ensure that calling setJob will reset the event result to JOB_STATUS_UNKNOWN
+     */
+    public function testSetJobResetsResult()
+    {
+        $event = new WorkerEvent($this->worker, $this->queue);
+        $event->setResult(WorkerEvent::JOB_STATUS_SUCCESS);
+
+        $job = new SimpleJob;
+        $event->setJob($job);
+
+        $this->assertEquals(WorkerEvent::JOB_STATUS_UNKNOWN, $event->getResult());
+    }
+
+    /**
+     * Ensure that an existing (previously processed) job can be removed from the event
+     */
+    public function testEventJobCanBeCleared()
+    {
+        $event = new WorkerEvent($this->worker, $this->queue);
+        $job = new SimpleJob;
+
+        $event->setJob($job);
+        $this->assertNotNull($event->getJob());
+
+        $event->setJob(null);
+        $this->assertNull($event->getJob());
+    }
 }


### PR DESCRIPTION
I've noticed jobs aren't cleared from the reused event when entering idle state. This PR fixes and tests that.