### PR TITLE
Syntax highlight fixes for the Events page

### DIFF
--- a/docs/6.Events.md
+++ b/docs/6.Events.md
@@ -40,9 +40,8 @@ gains the following capabilities;
 Configuration options are passed by the plugin manager to the constructor of an worker strategy. Setter methods will be
 called for each option. If a setter does not exist an exception will be thrown.
 
-```
+```php
 'SlmQueue\Strategy\MaxRunStrategy' => array('max_runs' => 10);
-
 ```
 Such a config will result in an MaxRunStrategy instance of which the setMaxRuns method is called with '10'.
 
@@ -54,7 +53,7 @@ thereafter removed from the passed options. This means a Worker Strategy cannot 
 Worker strategies may inform the worker to stop processing the queue. Or more concrete; invalidate the condition of
 the while loop.
 
-```
+```php
 public function onSomeListener(WorkerEvent $event)
 {
     $event->exitWorkerLoop();
@@ -67,7 +66,7 @@ public function onSomeListener(WorkerEvent $event)
 While processing a queue it might be required to execute some setup- or teardown logic. A worker strategy may listen to
 the `bootstrap` and/or `finish` event to do just this.
 
-```
+```php
 /**
  * @param EventManagerInterface $events
  */
@@ -106,7 +105,7 @@ For some types of jobs it might be required to do something before or after the 
 
 This can be done by listening to the `process` event at different priorities.
 
-```
+```php
 /**
  * @param EventManagerInterface $events
  */
@@ -148,7 +147,7 @@ the `WorkerEvent::EVENT_PROCESS_STATE` is received.
 
 From the MaxRunStrategy;
 
-```
+```php
 public function onSomeListener(WorkerEvent $event)
 {
     $this->runCount++;
@@ -169,7 +168,7 @@ A worker strategy may ask the worker to dispatch events.
 
 From the ProcessQueueStrategy
 
-```
+```php
 public function onJobPop(WorkerEvent $e)
 {
     $queue   = $e->getQueue();


### PR DESCRIPTION
Enable syntax highlighting for some of the code samples in the Events page.