### PR TITLE
EVENT_BOOTSTRAP is called multiple times for each strategy

### DIFF
--- a/src/Strategy/AttachQueueListenersStrategy.php
+++ b/src/Strategy/AttachQueueListenersStrategy.php
@@ -94,6 +94,6 @@ class AttachQueueListenersStrategy extends AbstractStrategy
         }
 
         $e->stopPropagation();
-        $eventManager->trigger(WorkerEvent::EVENT_BOOTSTRAP, $e);
+        $eventManager->trigger(WorkerEvent::EVENT_BOOTSTRAP, clone $e);
     }
 }

--- a/tests/Strategy/AttachQueueListenersStrategyTest.php
+++ b/tests/Strategy/AttachQueueListenersStrategyTest.php
@@ -138,4 +138,14 @@ class AttachQueueListenersStrategyTest extends PHPUnit_Framework_TestCase
         $this->setExpectedException('SlmQueue\Exception\RunTimeException');
         $this->listener->attachQueueListeners($this->event);
     }
+
+    public function testAttachQueueListenersBootstrapEventIsTriggeredOnlyOnce()
+    {
+        $workerMock       = $this->event->getTarget();
+        $eventManagerMock = $workerMock->getEventManager();
+        $eventManagerMock->expects($this->any())->method('getEvents')->will($this->returnValue(array(WorkerEvent::EVENT_PROCESS_QUEUE)));
+
+        $eventManagerMock->expects($this->once())->method('trigger')->with(WorkerEvent::EVENT_BOOTSTRAP, $this->logicalNot($this->identicalTo($this->event)));
+        $this->listener->attachQueueListeners($this->event);
+    }
 }


### PR DESCRIPTION
The EventManager sets the stopPropagation Flag to false in the trigger() method. Therefore the stopPropagation() call here does not work as expected and all listeners to the bootstrap event gets called twice.