### PR TITLE
Sometimes return codes are returned

### DIFF
--- a/src/Job/JobInterface.php
+++ b/src/Job/JobInterface.php
@@ -30,7 +30,7 @@ interface JobInterface extends MessageInterface
     /**
      * Execute the job
      *
-     * @return void
+     * @return void|int
      */
     public function execute();
 }


### PR DESCRIPTION
Void return type hint is not correct. Sometimes we need to return an integer return code, so [says the docs](https://github.com/juriansluiman/SlmQueue/blob/master/docs/3.Jobs.md#job-status-codes).