### PR TITLE
Provide SM3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,10 @@ cache:
     - $HOME/.composer/cache
     - vendor
 
-matrix:
-  fast_finish: true
-  include:
-    - php: 5.5
-    - php: 5.6
-    - php: 7
+php:
+  - 5.5
+  - 5.6
+  - 7
 
 env:
   matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,14 @@ matrix:
     - php: 5.6
     - php: 7
 
+env:
+  matrix:
+    - PREFER_LOWEST="--prefer-lowest"
+    - PREFER_LOWEST=""
+
 before_script:
   - composer self-update
-  - composer install --dev --prefer-source
+  - composer install --dev --prefer-source $PREFER_LOWEST
   - mkdir -p tests/build/logs
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 
 before_script:
   - composer self-update
-  - composer install --dev --prefer-source $PREFER_LOWEST
+  - composer update --prefer-source $PREFER_LOWEST
   - mkdir -p tests/build/logs
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-servicemanager": "~2.7 || ^3.0",
+        "zendframework/zend-servicemanager": "~2.7",
         "zendframework/zend-stdlib": "~2.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-servicemanager": "~2.2",
+        "zendframework/zend-servicemanager": "~2.6 || ^3.0",
         "zendframework/zend-stdlib": "~2.2"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -23,13 +23,21 @@
     ],
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-servicemanager": "~2.7",
-        "zendframework/zend-stdlib": "~2.2"
+        "zendframework/zend-servicemanager": "^2.7 || ^3.0",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "zendframework/zendframework": "~2.2",
-        "squizlabs/php_codesniffer": "~2.0",
-        "phpunit/phpunit": "~4.1"
+        "zendframework/zend-mvc": "^2.5",
+        "zendframework/zend-modulemanager": "^2.5",
+        "zendframework/zend-view": "^2.7",
+        "zendframework/zend-serializer": "^2.6",
+        "zendframework/zend-log": "^2.7",
+        "zendframework/zend-i18n": "^2.6",
+        "zendframework/zend-console": "^2.6",
+        "zendframework/zend-eventmanager": "^2.6",
+        "zendframework/zend-config": "^2.6",
+        "squizlabs/php_codesniffer": "^2.0",
+        "phpunit/phpunit": "^4.3"
     },
     "suggest": {
         "slm/queue-sqs": "If you are using Amazon SQS",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     ],
     "require": {
         "php": ">=5.5",
-        "zendframework/zend-servicemanager": "~2.6 || ^3.0",
+        "zendframework/zend-servicemanager": "~2.7 || ^3.0",
         "zendframework/zend-stdlib": "~2.2"
     },
     "require-dev": {

--- a/src/Factory/JobPluginManagerFactory.php
+++ b/src/Factory/JobPluginManagerFactory.php
@@ -22,11 +22,6 @@ class JobPluginManagerFactory implements FactoryInterface
         // adds invokables if the job name is not known, which will be sufficient most of the time
         $config = $container->get('config');
         $config = $config['slm_queue']['job_manager'];
-        $config = new Config($config);
-        /*
-         * For SM2 compatible
-         */
-        $config = method_exists($config, 'toArray')?$config->toArray():$config;
         $jobPluginManager = new JobPluginManager($container, $config);
 
         return $jobPluginManager;

--- a/src/Factory/JobPluginManagerFactory.php
+++ b/src/Factory/JobPluginManagerFactory.php
@@ -6,6 +6,7 @@ use SlmQueue\Job\JobPluginManager;
 use Zend\ServiceManager\Config;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use Interop\Container\ContainerInterface;
 
 /**
  * JobPluginManagerFactory
@@ -15,16 +16,27 @@ class JobPluginManagerFactory implements FactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function createService(ServiceLocatorInterface $serviceLocator)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         // We do not need to check if jobs is an empty array because every the JobPluginManager automatically
         // adds invokables if the job name is not known, which will be sufficient most of the time
-        $config = $serviceLocator->get('Config');
+        $config = $container->get('config');
         $config = $config['slm_queue']['job_manager'];
-
-        $jobPluginManager = new JobPluginManager(new Config($config));
-        $jobPluginManager->setServiceLocator($serviceLocator);
+        $config = new Config($config);
+        /*
+         * For SM2 compatible
+         */
+        $config = method_exists($config, 'toArray')?$config->toArray():$config;
+        $jobPluginManager = new JobPluginManager($container, $config);
 
         return $jobPluginManager;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, JobPluginManager::class);
     }
 }

--- a/src/Factory/QueueControllerPluginFactory.php
+++ b/src/Factory/QueueControllerPluginFactory.php
@@ -7,6 +7,7 @@ use SlmQueue\Job\JobPluginManager;
 use SlmQueue\Queue\QueuePluginManager;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use Interop\Container\ContainerInterface;
 
 /**
  * QueueControllerPluginFactory
@@ -16,12 +17,19 @@ class QueueControllerPluginFactory implements FactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function createService(ServiceLocatorInterface $serviceLocator)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $serviceLocator     = $serviceLocator->getServiceLocator();
-        $queuePluginManager = $serviceLocator->get(QueuePluginManager::class);
-        $jobPluginManager   = $serviceLocator->get(JobPluginManager::class);
+        $queuePluginManager = $container->get(QueuePluginManager::class);
+        $jobPluginManager   = $container->get(JobPluginManager::class);
 
         return new QueuePlugin($queuePluginManager, $jobPluginManager);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, QueuePlugin::class);
     }
 }

--- a/src/Factory/QueuePluginManagerFactory.php
+++ b/src/Factory/QueuePluginManagerFactory.php
@@ -6,6 +6,7 @@ use SlmQueue\Queue\QueuePluginManager;
 use Zend\ServiceManager\Config;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use Interop\Container\ContainerInterface;
 
 /**
  * QueuePluginManagerFactory
@@ -15,14 +16,25 @@ class QueuePluginManagerFactory implements FactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function createService(ServiceLocatorInterface $serviceLocator)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $config = $serviceLocator->get('Config');
+        $config = $container->get('config');
         $config = $config['slm_queue']['queue_manager'];
-
-        $queuePluginManager = new QueuePluginManager(new Config($config));
-        $queuePluginManager->setServiceLocator($serviceLocator);
+        $config = new Config($config);
+        /*
+         * For SM2 compatible
+         */
+        $config = method_exists($config, 'toArray')?$config->toArray():$config;
+        $queuePluginManager = new QueuePluginManager($container, $config);
 
         return $queuePluginManager;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, QueuePluginManager::class);
     }
 }

--- a/src/Factory/QueuePluginManagerFactory.php
+++ b/src/Factory/QueuePluginManagerFactory.php
@@ -20,11 +20,6 @@ class QueuePluginManagerFactory implements FactoryInterface
     {
         $config = $container->get('config');
         $config = $config['slm_queue']['queue_manager'];
-        $config = new Config($config);
-        /*
-         * For SM2 compatible
-         */
-        $config = method_exists($config, 'toArray')?$config->toArray():$config;
         $queuePluginManager = new QueuePluginManager($container, $config);
 
         return $queuePluginManager;

--- a/src/Factory/StrategyPluginManagerFactory.php
+++ b/src/Factory/StrategyPluginManagerFactory.php
@@ -20,11 +20,6 @@ class StrategyPluginManagerFactory implements FactoryInterface
     {
         $config = $container->get('config');
         $config = $config['slm_queue']['strategy_manager'];
-        $config = new Config($config);
-        /*
-         * For SM2 compatible
-         */
-        $config = method_exists($config, 'toArray')?$config->toArray():$config;
         $listenerPluginManager = new StrategyPluginManager($container, $config);
 
         return $listenerPluginManager;

--- a/src/Factory/StrategyPluginManagerFactory.php
+++ b/src/Factory/StrategyPluginManagerFactory.php
@@ -6,6 +6,7 @@ use SlmQueue\Strategy\StrategyPluginManager;
 use Zend\ServiceManager\Config;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use Interop\Container\ContainerInterface;
 
 /**
  * StrategyPluginManagerFactory
@@ -15,14 +16,25 @@ class StrategyPluginManagerFactory implements FactoryInterface
     /**
      * {@inheritDoc}
      */
-    public function createService(ServiceLocatorInterface $serviceLocator)
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $config = $serviceLocator->get('Config');
+        $config = $container->get('config');
         $config = $config['slm_queue']['strategy_manager'];
-
-        $listenerPluginManager = new StrategyPluginManager(new Config($config));
-        $listenerPluginManager->setServiceLocator($serviceLocator);
+        $config = new Config($config);
+        /*
+         * For SM2 compatible
+         */
+        $config = method_exists($config, 'toArray')?$config->toArray():$config;
+        $listenerPluginManager = new StrategyPluginManager($container, $config);
 
         return $listenerPluginManager;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, StrategyPluginManager::class);
     }
 }

--- a/src/Job/JobPluginManager.php
+++ b/src/Job/JobPluginManager.php
@@ -10,9 +10,16 @@ use SlmQueue\ServiceManager\AbstractPluginManager;
 class JobPluginManager extends AbstractPluginManager
 {
     /**
+     * SM2
      * @var bool
      */
     protected $shareByDefault = false;
+
+    /**
+     * SM3
+     * @var bool
+     */
+    protected $sharedByDefault = false;
 
     /**
      * @inheritdoc

--- a/src/Job/JobPluginManager.php
+++ b/src/Job/JobPluginManager.php
@@ -27,24 +27,31 @@ class JobPluginManager extends AbstractPluginManager
         // parent::get calls validatePlugin() so we're sure $instance is a JobInterface
         $instance = parent::get($name, $options, $usePeeringServiceManagers);
         $instance->setMetadata('__name__', $name);
-        
+
         return $instance;
     }
 
     /**
-     * @param  mixed $plugin
-     * @throws Exception\RuntimeException
-     * @return void
+     * {@inheritDoc}
      */
-    public function validatePlugin($plugin)
+    public function validate($instance)
     {
-        if ($plugin instanceof JobInterface) {
+        if ($instance instanceof JobInterface) {
             return; // we're okay
         }
 
         throw new Exception\RuntimeException(sprintf(
             'Plugin of type %s is invalid; must implement SlmQueue\Job\JobInterface',
-            (is_object($plugin) ? get_class($plugin) : gettype($plugin))
+            (is_object($instance) ? get_class($instance) : gettype($instance))
         ));
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function validatePlugin($plugin)
+    {
+        return $this->validate($plugin);
+    }
 }
+

--- a/src/Job/JobPluginManager.php
+++ b/src/Job/JobPluginManager.php
@@ -2,7 +2,7 @@
 
 namespace SlmQueue\Job;
 
-use Zend\ServiceManager\AbstractPluginManager;
+use SlmQueue\ServiceManager\AbstractPluginManager;
 
 /**
  * JobPluginManager
@@ -44,14 +44,6 @@ class JobPluginManager extends AbstractPluginManager
             'Plugin of type %s is invalid; must implement SlmQueue\Job\JobInterface',
             (is_object($instance) ? get_class($instance) : gettype($instance))
         ));
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function validatePlugin($plugin)
-    {
-        return $this->validate($plugin);
     }
 }
 

--- a/src/Job/JobPluginManager.php
+++ b/src/Job/JobPluginManager.php
@@ -46,4 +46,3 @@ class JobPluginManager extends AbstractPluginManager
         ));
     }
 }
-

--- a/src/Queue/QueuePluginManager.php
+++ b/src/Queue/QueuePluginManager.php
@@ -12,15 +12,23 @@ class QueuePluginManager extends AbstractPluginManager
     /**
      * {@inheritDoc}
      */
-    public function validatePlugin($plugin)
+    public function validate($instance)
     {
-        if ($plugin instanceof QueueInterface) {
+        if ($instance instanceof QueueInterface) {
             return; // we're okay!
         }
 
         throw new Exception\RuntimeException(sprintf(
             'Plugin of type %s is invalid; must implement SlmQueue\Queue\QueueInterface',
-            (is_object($plugin) ? get_class($plugin) : gettype($plugin))
+            (is_object($instance) ? get_class($instance) : gettype($instance))
         ));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function validatePlugin($plugin)
+    {
+        return $this->validate($plugin);
     }
 }

--- a/src/Queue/QueuePluginManager.php
+++ b/src/Queue/QueuePluginManager.php
@@ -2,7 +2,7 @@
 
 namespace SlmQueue\Queue;
 
-use Zend\ServiceManager\AbstractPluginManager;
+use SlmQueue\ServiceManager\AbstractPluginManager;
 
 /**
  * QueuePluginManager
@@ -22,13 +22,5 @@ class QueuePluginManager extends AbstractPluginManager
             'Plugin of type %s is invalid; must implement SlmQueue\Queue\QueueInterface',
             (is_object($instance) ? get_class($instance) : gettype($instance))
         ));
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function validatePlugin($plugin)
-    {
-        return $this->validate($plugin);
     }
 }

--- a/src/ServiceManager/AbstractPluginManager.php
+++ b/src/ServiceManager/AbstractPluginManager.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SlmQueue\ServiceManager;
+
+use Zend\ServiceManager\AbstractPluginManager as ZendAbstractPluginManager;
+use Zend\Stdlib\DispatchableInterface as Dispatchable;
+use Zend\Mvc\Controller\Plugin\PluginInterface;
+
+/**
+ * AbstractPluginManager
+ */
+abstract class AbstractPluginManager extends ZendAbstractPluginManager implements PluginInterface
+{
+    /**
+     *
+     * @var Dispatchable 
+     */
+    protected $controller;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function validatePlugin($plugin)
+    {
+        return $this->validate($plugin);
+    }
+
+    /**
+     *
+     * @return Dispatchable
+     */
+    public function getController()
+    {
+        return $this->controller;
+    }
+
+    /**
+     *
+     * @param Dispatchable $controller
+     * @return AbstractPluginManager
+     */
+    public function setController(Dispatchable $controller)
+    {
+        $this->controller = $controller;
+        return $this;
+    }
+}

--- a/src/ServiceManager/AbstractPluginManager.php
+++ b/src/ServiceManager/AbstractPluginManager.php
@@ -13,7 +13,7 @@ abstract class AbstractPluginManager extends ZendAbstractPluginManager implement
 {
     /**
      *
-     * @var Dispatchable 
+     * @var Dispatchable
      */
     protected $controller;
 

--- a/src/Strategy/Factory/AttachQueueListenersStrategyFactory.php
+++ b/src/Strategy/Factory/AttachQueueListenersStrategyFactory.php
@@ -6,12 +6,25 @@ use SlmQueue\Strategy\AttachQueueListenersStrategy;
 use SlmQueue\Strategy\StrategyPluginManager;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use Interop\Container\ContainerInterface;
 
 /**
  * AttachQueueListenersStrategyFactory
  */
 class AttachQueueListenersStrategyFactory implements FactoryInterface
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        $pluginManager  = $container->get(StrategyPluginManager::class);
+        $config         = $container->get('config');
+        $strategyConfig = $config['slm_queue']['worker_strategies']['queues'];
+
+        return new AttachQueueListenersStrategy($pluginManager, $strategyConfig);
+    }
+
     /**
      * Create service
      *
@@ -20,11 +33,6 @@ class AttachQueueListenersStrategyFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $sm             = $serviceLocator->getServiceLocator();
-        $pluginManager  = $sm->get(StrategyPluginManager::class);
-        $config         = $sm->get('Config');
-        $strategyConfig = $config['slm_queue']['worker_strategies']['queues'];
-
-        return new AttachQueueListenersStrategy($pluginManager, $strategyConfig);
+        return $this($serviceLocator, AttachQueueListenersStrategy::class);
     }
 }

--- a/src/Strategy/Factory/AttachQueueListenersStrategyFactory.php
+++ b/src/Strategy/Factory/AttachQueueListenersStrategyFactory.php
@@ -33,6 +33,6 @@ class AttachQueueListenersStrategyFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return $this($serviceLocator, AttachQueueListenersStrategy::class);
+        return $this($serviceLocator->getServiceLocator(), AttachQueueListenersStrategy::class);
     }
 }

--- a/src/Strategy/Factory/LogJobStrategyFactory.php
+++ b/src/Strategy/Factory/LogJobStrategyFactory.php
@@ -36,6 +36,6 @@ class LogJobStrategyFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return $this($serviceLocator, LogJobStrategy::class);
+        return $this($serviceLocator->getServiceLocator(), LogJobStrategy::class);
     }
 }

--- a/src/Strategy/Factory/LogJobStrategyFactory.php
+++ b/src/Strategy/Factory/LogJobStrategyFactory.php
@@ -4,6 +4,7 @@ namespace SlmQueue\Strategy\Factory;
 use SlmQueue\Strategy\LogJobStrategy;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
+use Interop\Container\ContainerInterface;
 
 /**
  * LogJobStrategyFactory
@@ -16,6 +17,17 @@ class LogJobStrategyFactory implements FactoryInterface
     {
         $this->options = $options;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        $strategy = new LogJobStrategy($container->get('console'), $this->options);
+
+        return $strategy;
+    }
+
     /**
      * Create service
      *
@@ -24,8 +36,6 @@ class LogJobStrategyFactory implements FactoryInterface
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $strategy = new LogJobStrategy($serviceLocator->getServiceLocator()->get('Console'), $this->options);
-
-        return $strategy;
+        return $this($serviceLocator, LogJobStrategy::class);
     }
 }

--- a/src/Strategy/StrategyPluginManager.php
+++ b/src/Strategy/StrategyPluginManager.php
@@ -30,4 +30,3 @@ class StrategyPluginManager extends AbstractPluginManager
         ));
     }
 }
-

--- a/src/Strategy/StrategyPluginManager.php
+++ b/src/Strategy/StrategyPluginManager.php
@@ -16,19 +16,26 @@ class StrategyPluginManager extends AbstractPluginManager
     protected $shareByDefault = false;
 
     /**
-     * @param  mixed $plugin
-     * @throws RuntimeException
-     * @return void
+     * {@inheritDoc}
      */
-    public function validatePlugin($plugin)
+    public function validate($instance)
     {
-        if ($plugin instanceof AbstractStrategy) {
+        if ($instance instanceof AbstractStrategy) {
             return; // we're okay
         }
 
         throw new RuntimeException(sprintf(
             'Plugin of type %s is invalid; must extend SlmQueue\Strategy\AbstractStrategy',
-            (is_object($plugin) ? get_class($plugin) : gettype($plugin))
+            (is_object($instance) ? get_class($instance) : gettype($instance))
         ));
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function validatePlugin($plugin)
+    {
+        return $this->validate($plugin);
+    }
 }
+

--- a/src/Strategy/StrategyPluginManager.php
+++ b/src/Strategy/StrategyPluginManager.php
@@ -3,7 +3,7 @@
 namespace SlmQueue\Strategy;
 
 use SlmQueue\Exception\RuntimeException;
-use Zend\ServiceManager\AbstractPluginManager;
+use SlmQueue\ServiceManager\AbstractPluginManager;
 
 /**
  * StrategyPluginManager
@@ -28,14 +28,6 @@ class StrategyPluginManager extends AbstractPluginManager
             'Plugin of type %s is invalid; must extend SlmQueue\Strategy\AbstractStrategy',
             (is_object($instance) ? get_class($instance) : gettype($instance))
         ));
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    public function validatePlugin($plugin)
-    {
-        return $this->validate($plugin);
     }
 }
 

--- a/tests/Asset/SimpleQueueFactory.php
+++ b/tests/Asset/SimpleQueueFactory.php
@@ -1,6 +1,8 @@
 <?php
 
 namespace SlmQueueTest\Asset;
+
+use Interop\Container\ContainerInterface;
 use SlmQueue\Job\JobPluginManager;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
@@ -13,12 +15,18 @@ class SimpleQueueFactory implements FactoryInterface
     /**
      * {@inheritDoc}
      */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        $jobPluginManager = new JobPluginManager($container);
+
+        return new SimpleQueue($requestedName, $jobPluginManager);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     public function createService(ServiceLocatorInterface $serviceLocator, $name = '', $requestedName = '')
     {
-        $jobPluginManager = new JobPluginManager();
-
-        $queue = new SimpleQueue($requestedName, $jobPluginManager);
-
-        return $queue;
+        return $this($serviceLocator, $requestedName);
     }
 }

--- a/tests/Factory/QueueControllerPluginFactoryTest.php
+++ b/tests/Factory/QueueControllerPluginFactoryTest.php
@@ -3,6 +3,7 @@
 namespace SlmQueueTest\Factory;
 
 use PHPUnit_Framework_TestCase as TestCase;
+use SlmQueue\Controller\Plugin\QueuePlugin;
 use SlmQueue\Factory\QueueControllerPluginFactory;
 use SlmQueueTest\Util\ServiceManagerFactory;
 
@@ -12,10 +13,9 @@ class QueueControllerPluginFactoryTest extends TestCase
     public function testCreateService()
     {
         $serviceManager               = ServiceManagerFactory::getServiceManager();
-        $controllerPluginManager      = $serviceManager->get('ControllerPluginManager');
         $factory                      = new QueueControllerPluginFactory();
-        $queueControllerPluginFactory = $factory->createService($controllerPluginManager);
 
-        $this->assertInstanceOf('SlmQueue\Controller\Plugin\QueuePlugin', $queueControllerPluginFactory);
+        $queueControllerPluginFactory = $factory($serviceManager, QueuePlugin::class);
+        $this->assertInstanceOf(QueuePlugin::class, $queueControllerPluginFactory);
     }
 }

--- a/tests/Job/JobPluginManagerTest.php
+++ b/tests/Job/JobPluginManagerTest.php
@@ -3,8 +3,10 @@
 namespace SlmQueueTest\Job;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use SlmQueue\Job\JobPluginManager;
+use SlmQueueTest\Asset\SimpleJob;
 use SlmQueueTest\Util\ServiceManagerFactory;
+use SlmQueue\Job\Exception\RuntimeException;
+use SlmQueue\Job\JobPluginManager;
 use Zend\ServiceManager\ServiceManager;
 
 class JobPluginManagerTest extends TestCase
@@ -22,37 +24,39 @@ class JobPluginManagerTest extends TestCase
 
     public function testCanRetrievePluginManagerWithServiceManager()
     {
-        $jobPluginManager = $this->serviceManager->get('SlmQueue\Job\JobPluginManager');
-        $this->assertInstanceOf('SlmQueue\Job\JobPluginManager', $jobPluginManager);
+        $jobPluginManager = $this->serviceManager->get(JobPluginManager::class);
+        $this->assertInstanceOf(JobPluginManager::class, $jobPluginManager);
     }
 
     public function testAskingTwiceForTheSameJobReturnsDifferentInstances()
     {
-        $jobPluginManager = $this->serviceManager->get('SlmQueue\Job\JobPluginManager');
+        $jobPluginManager = $this->serviceManager->get(JobPluginManager::class);
 
-        $firstInstance  = $jobPluginManager->get('SlmQueueTest\Asset\SimpleJob');
-        $secondInstance = $jobPluginManager->get('SlmQueueTest\Asset\SimpleJob');
+        $firstInstance  = $jobPluginManager->get(SimpleJob::class);
+        $secondInstance = $jobPluginManager->get(SimpleJob::class);
 
         $this->assertNotSame($firstInstance, $secondInstance);
     }
 
     public function testPluginManagerSetsServiceNameAsMetadata()
     {
-        $jobPluginManager = new JobPluginManager;
-        $jobPluginManager->setInvokableClass('SimpleJob', 'SlmQueueTest\Asset\SimpleJob');
+        $serviceManager = new ServiceManager();
+        $jobPluginManager = new JobPluginManager($serviceManager);
+        $jobPluginManager->setInvokableClass('SimpleJob', SimpleJob::class);
 
         $instance = $jobPluginManager->get('SimpleJob');
 
-        $this->assertInstanceOf('SlmQueueTest\Asset\SimpleJob', $instance);
+        $this->assertInstanceOf(SimpleJob::class, $instance);
         $this->assertEquals('SimpleJob', $instance->getMetadata('__name__'));
     }
 
     public function testPluginManagerThrowsExceptionOnInvalidJobClasses()
     {
-        $jobPluginManager = new JobPluginManager;
+        $serviceManager = new ServiceManager();
+        $jobPluginManager = new JobPluginManager($serviceManager);
         $jobPluginManager->setInvokableClass('InvalidJob', 'stdClass');
 
-        $this->setExpectedException('SlmQueue\Job\Exception\RuntimeException');
+        $this->setExpectedException(RuntimeException::class);
 
         $instance = $jobPluginManager->get('InvalidJob');
     }

--- a/tests/Queue/QueueAwareTraitTest.php
+++ b/tests/Queue/QueueAwareTraitTest.php
@@ -3,9 +3,10 @@
 namespace SlmQueueTest\Queue;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use SlmQueue\Job\JobPluginManager;
 use SlmQueueTest\Asset\QueueAwareTraitJob;
 use SlmQueueTest\Asset\SimpleQueue;
+use SlmQueue\Job\JobPluginManager;
+use Zend\ServiceManager\ServiceManager;
 
 class QueueAwareTraitTest extends TestCase
 {
@@ -33,7 +34,9 @@ class QueueAwareTraitTest extends TestCase
 
     public function testSetter()
     {
-        $queue = new SimpleQueue('name', new JobPluginManager());
+        $serviceManager = new ServiceManager();
+        $jobPluginManager = new JobPluginManager($serviceManager);
+        $queue = new SimpleQueue('name', $jobPluginManager);
         $this->job->setQueue($queue);
 
         $this->assertNotNull($this->job->getQueue());

--- a/tests/Queue/QueuePluginManagerTest.php
+++ b/tests/Queue/QueuePluginManagerTest.php
@@ -4,6 +4,7 @@ namespace SlmQueueTest\Queue;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use SlmQueue\Queue\QueuePluginManager;
+use SlmQueue\Queue\Exception\RuntimeException;
 use SlmQueueTest\Util\ServiceManagerFactory;
 use Zend\ServiceManager\ServiceManager;
 
@@ -22,13 +23,13 @@ class QueuePluginManagerTest extends TestCase
 
     public function testCanRetrievePluginManagerWithServiceManager()
     {
-        $queuePluginManager = $this->serviceManager->get('SlmQueue\Queue\QueuePluginManager');
-        $this->assertInstanceOf('SlmQueue\Queue\QueuePluginManager', $queuePluginManager);
+        $queuePluginManager = $this->serviceManager->get(QueuePluginManager::class);
+        $this->assertInstanceOf(QueuePluginManager::class, $queuePluginManager);
     }
 
     public function testAskingTwiceTheSameQueueReturnsTheSameInstance()
     {
-        $queuePluginManager = $this->serviceManager->get('SlmQueue\Queue\QueuePluginManager');
+        $queuePluginManager = $this->serviceManager->get(QueuePluginManager::class);
 
         $firstInstance  = $queuePluginManager->get('basic-queue');
         $secondInstance = $queuePluginManager->get('basic-queue');
@@ -38,10 +39,11 @@ class QueuePluginManagerTest extends TestCase
 
     public function testPluginValidation()
     {
-        $manager = new QueuePluginManager();
+        $serviceManager = new ServiceManager();
+        $manager = new QueuePluginManager($serviceManager);
         $queue   = new \stdClass();
 
-        $this->setExpectedException('SlmQueue\Queue\Exception\RuntimeException');
+        $this->setExpectedException(RuntimeException::class);
         $manager->validatePlugin($queue);
     }
 }

--- a/tests/Queue/QueueTest.php
+++ b/tests/Queue/QueueTest.php
@@ -5,8 +5,10 @@ namespace SlmQueueTest\Queue;
 use DateTime;
 use PHPUnit_Framework_TestCase as TestCase;
 use SlmQueueTest\Asset\QueueAwareJob;
-use SlmQueueTest\Asset\SimpleQueue;
 use SlmQueueTest\Asset\SimpleJob;
+use SlmQueueTest\Asset\SimpleQueue;
+use SlmQueue\Job\JobPluginManager;
+use Zend\ServiceManager\ServiceManager;
 
 class QueueTest extends TestCase
 {
@@ -18,9 +20,10 @@ class QueueTest extends TestCase
     public function setUp()
     {
         $this->job     = new SimpleJob;
-        $this->jobName = 'SlmQueueTest\Asset\SimpleJob';
+        $this->jobName = SimpleJob::class;
+        $serviceManager = new ServiceManager();
 
-        $this->jobPluginManager = $this->getMock('SlmQueue\Job\JobPluginManager');
+        $this->jobPluginManager = $this->getMock(JobPluginManager::class, [], [$serviceManager]);
         $this->queue = new SimpleQueue('queue', $this->jobPluginManager);
     }
 

--- a/tests/Strategy/AttachQueueListenersStrategyTest.php
+++ b/tests/Strategy/AttachQueueListenersStrategyTest.php
@@ -6,6 +6,7 @@ use PHPUnit_Framework_TestCase;
 use SlmQueue\Strategy\AttachQueueListenersStrategy;
 use SlmQueue\Worker\WorkerEvent;
 use SlmQueueTest\Asset\SimpleJob;
+use Zend\ServiceManager\ServiceManager;
 
 class AttachQueueListenersStrategyTest extends PHPUnit_Framework_TestCase
 {
@@ -21,13 +22,14 @@ class AttachQueueListenersStrategyTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $jobPluginManager      = $this->getMock('SlmQueue\Job\JobPluginManager');
+        $serviceManager = new ServiceManager();
+        $jobPluginManager      = $this->getMock('SlmQueue\Job\JobPluginManager', [], [$serviceManager]);
         $queue                 = $this->getMock(
             'SlmQueue\Queue\AbstractQueue',
             [],
             ['queueName', $jobPluginManager]
         );
-        $strategyPluginManager = $this->getMock('SlmQueue\Strategy\StrategyPluginManager');
+        $strategyPluginManager = $this->getMock('SlmQueue\Strategy\StrategyPluginManager', [], [$serviceManager]);
         $eventManager          = $this->getMock('Zend\EventManager\EventManager');
         $worker                = $this->getMock('SlmQueue\Worker\AbstractWorker', [], [$eventManager]);
         $strategyMock          = $this->getMock('SlmQueue\Strategy\AbstractStrategy');

--- a/tests/Strategy/Factory/LogJobFactoryTest.php
+++ b/tests/Strategy/Factory/LogJobFactoryTest.php
@@ -3,24 +3,21 @@
 namespace SlmQueueTest\Strategy\Factory;
 
 use PHPUnit_Framework_TestCase as TestCase;
-use SlmQueue\Strategy\Factory\LogJobStrategyFactory;
-use SlmQueue\Strategy\StrategyPluginManager;
 use SlmQueueTest\Util\ServiceManagerFactory;
+use SlmQueue\Strategy\Factory\LogJobStrategyFactory;
+use SlmQueue\Strategy\LogJobStrategy;
 
 class LogJobFactoryTest extends TestCase
 {
 
     public function testCreateService()
     {
-        $plugin   = new StrategyPluginManager();
-        $sm       = ServiceManagerFactory::getServiceManager();
-
-        $plugin->setServiceLocator($sm);
+        $serviceManager       = ServiceManagerFactory::getServiceManager();
 
         $factory  = new LogJobStrategyFactory();
-        $strategy = $factory->createService($plugin);
+        $strategy = $factory($serviceManager, LogJobStrategy::class);
 
-        $this->assertInstanceOf('SlmQueue\Strategy\LogJobStrategy', $strategy);
+        $this->assertInstanceOf(LogJobStrategy::class, $strategy);
     }
 
 }

--- a/tests/Util/ServiceManagerFactory.php
+++ b/tests/Util/ServiceManagerFactory.php
@@ -49,9 +49,17 @@ class ServiceManagerFactory
      */
     public static function getServiceManager()
     {
-        $serviceManager = new ServiceManager(new ServiceManagerConfig(
+        $serviceManagerConfig = new ServiceManagerConfig(
             isset(static::$config['service_manager']) ? static::$config['service_manager'] : []
-        ));
+        );
+        /*
+         * get array for new ServiceManager
+         */
+        $config = (method_exists($serviceManagerConfig, 'toArray')
+            && method_exists(ServiceManager::class, 'configure')) ?
+            $serviceManagerConfig->toArray() : $serviceManagerConfig;
+
+        $serviceManager = new ServiceManager($config);
         $serviceManager->setService('ApplicationConfig', static::$config);
         $serviceManager->setAllowOverride(true);
         $serviceManager->setFactory('ServiceListener', 'Zend\Mvc\Service\ServiceListenerFactory');
@@ -60,7 +68,6 @@ class ServiceManagerFactory
         /** @var $moduleManager \Zend\ModuleManager\ModuleManager */
         $moduleManager = $serviceManager->get('ModuleManager');
         $moduleManager->loadModules();
-        //$serviceManager->setAllowOverride(true);
         return $serviceManager;
     }
 }

--- a/tests/Util/ServiceManagerFactory.php
+++ b/tests/Util/ServiceManagerFactory.php
@@ -53,7 +53,9 @@ class ServiceManagerFactory
             isset(static::$config['service_manager']) ? static::$config['service_manager'] : []
         ));
         $serviceManager->setService('ApplicationConfig', static::$config);
+        $serviceManager->setAllowOverride(true);
         $serviceManager->setFactory('ServiceListener', 'Zend\Mvc\Service\ServiceListenerFactory');
+        $serviceManager->setAllowOverride(false);
 
         /** @var $moduleManager \Zend\ModuleManager\ModuleManager */
         $moduleManager = $serviceManager->get('ModuleManager');

--- a/tests/testing.config.php
+++ b/tests/testing.config.php
@@ -29,7 +29,14 @@ return [
         'queue_manager' => [
             'factories' => [
                 'basic-queue' => function ($locator) {
-                    $parentLocator    = $locator->getServiceLocator();
+                    /*
+                     * avoid calling deprecated ServiceLocator on SM3
+                     */
+                    if ($locator->has('SlmQueue\Job\JobPluginManager')) {
+                        $parentLocator    = $locator;
+                    } else {
+                        $parentLocator    = $locator->getServiceLocator();
+                    }
                     $jobPluginManager = $parentLocator->get('SlmQueue\Job\JobPluginManager');
 
                     return new \SlmQueueTest\Asset\SimpleQueue('basic-queue', $jobPluginManager);


### PR DESCRIPTION
Due to #179 issue.

There is a lot changes.
I do not change tests a lot, that PR could pass all tests on 2.7 SM version, but didn't on 3.0. (Cause rewriting tests needed, that adds BC).

You could check that on changing composer.json to
```json
"zendframework/zend-servicemanager": "~2.7",
```