### PR TITLE
Changed the job status class from WorkerEvent to ProcessJobEvent

### DIFF
--- a/docs/3.Jobs.md
+++ b/docs/3.Jobs.md
@@ -225,7 +225,7 @@ its status code. SlmQueue defines the following default status codes:
 2. `JOB_STATUS_FAILURE`
 3. `JOB_STATUS_FAILURE_RECOVERABLE`
 
-The status codes are stored in the WorkerEvent object (more on that at the 
+The status codes are stored in the ProcessJobEvent object (more on that at the 
 [event section](6.Events.md)). Normally when jobs are completely executed, the status is 
 success. If any exception is thrown, the status is set to failure.
 
@@ -260,14 +260,14 @@ method:
 
 ```php
 use SlmQueue\Job\AbstractJob;
-use SlmQueue\Worker\WorkerEvent;
+use \SlmQueue\Worker\Event\ProcessJobEvent;
 
 class RecoverableJob extends AbstractJob
 {
     public function execute()
     {
         // Ooops, something went wrong?
-        return WorkerEvent::JOB_STATUS_FAILURE_RECOVERABLE;
+        return ProcessJobEvent::JOB_STATUS_FAILURE_RECOVERABLE;
     }
 }
 ```


### PR DESCRIPTION
The documentation referenced the WorkerEvent class to contain constants for the different default statuses. In reality, these have moved to  ProcessJobEvent. This commit fixes those references.

Thanks for creating this library, really helping me out!