### PR TITLE
Update QueuePlugin::push to return Job

### DIFF
--- a/src/Controller/Plugin/QueuePlugin.php
+++ b/src/Controller/Plugin/QueuePlugin.php
@@ -90,6 +90,8 @@ class QueuePlugin extends AbstractPlugin
             $job->setContent($payload);
         }
 
-        return $this->queue->push($job, $options);
+        $this->queue->push($job, $options);
+        
+        return $job;
     }
 }

--- a/tests/Controller/Plugin/QueueTest.php
+++ b/tests/Controller/Plugin/QueueTest.php
@@ -78,7 +78,7 @@ class QueueTest extends TestCase
         $queue->expects($this->once())
               ->method('push')
               ->with($job)
-              ->will($this->returnValue($job));
+              ->will($this->returnValue(null));
         $queuePluginManager->setService($name, $queue);
         $jobPluginManager->setService('SimpleJob', $job);
 
@@ -102,7 +102,7 @@ class QueueTest extends TestCase
         $queue->expects($this->once())
               ->method('push')
               ->with($job)
-              ->will($this->returnValue($job));
+              ->will($this->returnValue(null));
         $queuePluginManager->setService($name, $queue);
         $jobPluginManager->setService('SimpleJob', $job);
 


### PR DESCRIPTION
$this->queue->push() returns void, so the job never gets returned. Updated it so it will return the job. The tests were passing because the push method on the queue is being mocked to return the job, but the QueueInterface::push() method has a return type of void, so this is wrong. I haven't updated the tests to take this into account. Want me to do that?