### PR TITLE
Allow pushing a job instance via the controller plugin

### DIFF
--- a/src/Controller/Plugin/QueuePlugin.php
+++ b/src/Controller/Plugin/QueuePlugin.php
@@ -79,11 +79,7 @@ class QueuePlugin extends AbstractPlugin
      */
     public function push($name, $payload = null, array $options = [])
     {
-        if (null === $this->queue) {
-            throw new QueueNotFoundException(
-                'You cannot push a job without a queue selected'
-            );
-        }
+        $this->assertQueueIsSet();
 
         $job = $this->jobPluginManager->get($name);
         if (null !== $payload) {
@@ -93,5 +89,32 @@ class QueuePlugin extends AbstractPlugin
         $this->queue->push($job, $options);
         
         return $job;
+    }
+
+    /**
+     * Push a job on the selected queue
+     *
+     * @param JobInterface $job
+     * @param array $options Push job options
+      * @throws QueueNotFoundException If the method is called without a queue set
+     */
+    public function pushJob(JobInterface $job, array $options = [])
+    {
+        $this->assertQueueIsSet();
+
+        $this->queue->push($job, $options);
+    }
+
+    /**
+     * @throws QueueNotFoundException
+     */
+    protected function assertQueueIsSet()
+    {
+        if (null === $this->queue) {
+            throw new QueueNotFoundException(
+                'You cannot push a job without a queue selected'
+            );
+        }
+
     }
 }

--- a/src/Controller/Plugin/QueuePlugin.php
+++ b/src/Controller/Plugin/QueuePlugin.php
@@ -115,6 +115,5 @@ class QueuePlugin extends AbstractPlugin
                 'You cannot push a job without a queue selected'
             );
         }
-
     }
 }


### PR DESCRIPTION
The controller plugin that comes with this repo does not allow to push a job by instance. 

This PR adds that functionality in the following way:

```php
$this->queue()->pushJob(SendSlackMessage::create('@me', 'Hello'), ['delay' => 3]);
```

Curious to hear what you think about this one @basz and @bakura10.